### PR TITLE
Remove Google Fonts and Font Awesome. Now using system fonts and inline SVG

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,7 +14,7 @@
  *= require_self
  */
 body {
-	font-family: 'Open Sans', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, ubuntu, roboto, noto, segoe ui, helvetica, helvetica neue, arial, sans-serif;
 	background: #F1F1F1;
 }
 h1 {
@@ -35,13 +35,19 @@ i {
     margin: auto;
     margin-bottom: 20px;
     background: #FFF;
-    padding: 10px;
+    padding: 16px;
     border-radius: 1px;
     box-shadow: 0px 1px 2px #CCC;
+		line-height: 20px;
 }
+
+.matiere > p {
+	display: flex;
+}
+
 .date {
-	width: 92%;
-	padding: 10px;
+	width: 100%;
+	padding-bottom: 16px;
 	color: #e74c3c;
 	border-bottom: 1px solid #DDD;
 	font-size: 130%;
@@ -78,13 +84,32 @@ i {
 .text-center {
 	text-align: center
 }
-a:hover {
-	background: #c0392b;
-}
+
 .home {
 	position: absolute;
 	top: 20px;
 	left: 20px;
 	font-size: 140%;
 	z-index: 9;
+}
+
+a:hover{
+	background-color: #c0392b;
+}
+
+.home:hover {
+	background-color: transparent;
+}
+.home:hover svg path{
+	fill: #c0392b;
+}
+
+p {
+	margin-bottom: 0;
+}
+
+.icon {
+	width: 18px;
+	height: 18px;
+	margin: 3px 16px 3px 0px;
 }

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,13 +1,11 @@
 body {
   background-color: #fff;
   color: #333;
-  font-family: verdana, arial, helvetica, sans-serif;
   font-size: 13px;
   line-height: 18px;
 }
 
 p, ol, ul, td {
-  font-family: verdana, arial, helvetica, sans-serif;
   font-size: 13px;
   line-height: 18px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,13 +6,11 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <link rel="apple-touch-icon" type="image/png" href="<%= image_path('icon.png');%>">
 <link rel="shortcut icon" href="<%= image_path('icon.png');%>" type="image/x-icon">
-<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css"/>
 <!-- Add the slick-theme.css if you want default styling -->
 <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css"/>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/app/views/sources/show.html.erb
+++ b/app/views/sources/show.html.erb
@@ -1,5 +1,7 @@
 <%= link_to '/', class: 'home' do %>
-  <i class="fa fa-home"></i>
+<svg class="icon" viewBox="0 0 24 24">
+  <path fill="#000000" d="M10,20V14H14V20H19V12H22L12,3L2,12H5V20H10Z" />
+</svg>
 <% end %>
 <div class="calendar">
     <% @events.each_with_index do |event, index| %>
@@ -19,9 +21,24 @@
       <% end %>
         <div class="matiere">
           <span class="date">De <strong><%= (event.starts_at + 2.hours).strftime("%Hh%M") %></strong> à <strong><%= (event.ends_at + 2.hours).strftime("%Hh%M") %></strong></span>
-          <p><i class="fa fa-pencil"></i> <%= event.title %></p>
-          <p><i class="fa fa-map-marker"></i> <%= event.room %></p>
-          <p><i class="fa fa-university"></i> <%= event.teacher %></p>
+          <p>
+            <svg class="icon" viewBox="0 0 24 24">
+              <path fill="#000000" d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z" />
+            </svg>
+            <span><%= event.title %></span>
+          </p>
+          <p>
+            <svg class="icon" viewBox="0 0 24 24">
+              <path fill="#000000" d="M12,11.5A2.5,2.5 0 0,1 9.5,9A2.5,2.5 0 0,1 12,6.5A2.5,2.5 0 0,1 14.5,9A2.5,2.5 0 0,1 12,11.5M12,2A7,7 0 0,0 5,9C5,14.25 12,22 12,22C12,22 19,14.25 19,9A7,7 0 0,0 12,2Z" />
+            </svg>
+            <%= event.room %>
+          </p>
+          <p>
+            <svg class="icon" viewBox="0 0 24 24">
+              <path fill="#000000" d="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z" />
+            </svg>
+            <%= event.teacher %>
+          </p>
         </div>
     <% end %>
   </div>
@@ -29,7 +46,7 @@
 <script>
 $('.calendar').slick({arrows: false, infinite: false});
 $(document).keydown(function(e){
-  if (e.keyCode == 39) { 
+  if (e.keyCode == 39) {
      $('.calendar').slick('slickNext');
   } else if (e.keyCode == 37) {
     $('.calendar').slick('slickPrev');


### PR DESCRIPTION
Since the app targets mobile devices, I thought it would be great to reduce the load time by using system fonts instead of Google Fonts and inline SVG instead of Font Awesome. Moreover, inline SVG  are better for accessibility (and HTML semantics).
